### PR TITLE
get rid from eval

### DIFF
--- a/src/ngu-carousel/ngu-carousel.component.ts
+++ b/src/ngu-carousel/ngu-carousel.component.ts
@@ -311,8 +311,7 @@ export class NguCarouselComponent
 
     // remove listeners
     for (let i = 1; i <= 8; i++) {
-      // tslint:disable-next-line:no-eval
-      eval(`this.listener${i} && this.listener${i}()`);
+      this[`listener${i}`] && this[`listener${i}`]();
     }
   }
 


### PR DESCRIPTION
to avoid an error ```Error: Uncaught (in promise): EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self'".```