### PR TITLE
function type check to prevent crash

### DIFF
--- a/src/app/carousel/ngu-carousel/ngu-carousel.component.ts
+++ b/src/app/carousel/ngu-carousel/ngu-carousel.component.ts
@@ -237,8 +237,10 @@ export class NguCarousel
     this.carouselLoad.complete();
 
     // remove listeners
-    for (let i = 1; i <= 8; i++) {
-      this[`listener${i}`] && this[`listener${i}`]();
+    if (isPlatformBrowser(this.platformId)) {
+      for (let i = 1; i <= 8; i++) {
+        this[`listener${i}`] && this[`listener${i}`]();
+      }
     }
   }
 


### PR DESCRIPTION
We need to ensure those listeners are functions before call it.
I got this error from SSR:
```
TypeError: this.listener1 is not a function
    at NguCarouselComponent.module.exports.NguCarouselComponent.ngOnDestroy (/var/task/dist/server.js:175618:14)
    at callProviderLifecycles (/var/task/dist/server.js:13032:18)
    at callElementProvidersLifecycles (/var/task/dist/server.js:12997:13)
    at callLifecycleHooksChildrenFirst (/var/task/dist/server.js:12981:17)
    at destroyView (/var/task/dist/server.js:14325:5)
    at callViewAction (/var/task/dist/server.js:14476:13)
    at execEmbeddedViewsAction (/var/task/dist/server.js:14414:17)
    at destroyView (/var/task/dist/server.js:14323:5)
    at callViewAction (/var/task/dist/server.js:14476:13)
    at execComponentViewsAction (/var/task/dist/server.js:14388:13)
```