### PR TITLE
Removed unnecessary styles in carousel tile

### DIFF
--- a/projects/carousel/src/lib/ngu-tile/ngu-tile.component.scss
+++ b/projects/carousel/src/lib/ngu-tile/ngu-tile.component.scss
@@ -1,8 +1,3 @@
 :host {
-  padding: 10px;
   box-sizing: border-box;
-}
-
-.tile {
-  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12);
 }


### PR DESCRIPTION
The padding and box-shadow are opinionated styles and  sould not be included here, since the premise of the carousel is "This carousel doesn't include any css".